### PR TITLE
save capture parameters to params.txt

### DIFF
--- a/cavicapture.py
+++ b/cavicapture.py
@@ -99,6 +99,15 @@ current_gains = camera.awb_gains
 camera.awb_mode = 'off'
 camera.awb_gains = current_gains
 
+#Save capture parameters to file
+params = open('params.txt', 'a');
+params.write('start: '+datetime.datetime.now().strftime('%Y%m%d-%H%M%S')+'\n');
+params.write('interval (s): %d\n' % interval);
+params.write('duration (s): %d\n' % duration);
+params.write('shutter speed (ms): %d\n' % camera.shutter_speed);
+params.write('\n\n');
+params.close();
+
 print("Configuration complete. Running sequence.")
 
 last_file = ''


### PR DESCRIPTION
saves selected parameters interval, duration and shutter speed to params.txt in the active directory.
new lines are appended to file if params.txt already exists (e.g. after an outage)